### PR TITLE
Fix npm module name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ A module to make dynamodb client creation environment agnostic.
 
 ## Installation
 
-`npm install --save sls-dynamodb-client`
+`npm install --save @kartikrao/sls-dynamodb-client`
 
 ## Usage
 


### PR DESCRIPTION
`sls-dynamodb-client` is a different npm package: https://www.npmjs.com/package/sls-dynamodb-client